### PR TITLE
Add GitHub Action to build Devbox image on a schedule

### DIFF
--- a/.github/workflows/devbox-build.yml
+++ b/.github/workflows/devbox-build.yml
@@ -1,0 +1,18 @@
+name: Build Devbox Image
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: namespace-profile-default
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Devbox CLI
+        run: curl -fsSL get.namespace.so/devbox/install.sh | bash
+
+      - name: Build Devbox image
+        run: devbox image build . --name=rcrowe-dotfiles -f .devbox/Dockerfile


### PR DESCRIPTION
Adds a workflow that runs every 30 minutes (and on manual dispatch) on a Namespace.so runner to rebuild the Devbox container image.

### Steps
1. Installs the Devbox CLI
2. Runs `devbox image build . --name=rcrowe-dotfiles -f .devbox/Dockerfile`

No extra auth is needed — Namespace runners include a short-lived workload identity token automatically.