### PR TITLE
Fix Namespace auth for Devbox image build

### DIFF
--- a/.github/workflows/devbox-build.yml
+++ b/.github/workflows/devbox-build.yml
@@ -5,11 +5,18 @@ on:
     - cron: "*/30 * * * *"
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: namespace-profile-default
     steps:
       - uses: actions/checkout@v4
+
+      - name: Configure access to Namespace
+        uses: namespacelabs/nscloud-setup@v0
 
       - name: Install Devbox CLI
         run: curl -fsSL get.namespace.so/devbox/install.sh | bash


### PR DESCRIPTION
Adds OIDC federation setup to fix `PermissionDenied` error when building the Devbox image.

- Adds `id-token: write` permission for OpenID Connect federation
- Adds `namespacelabs/nscloud-setup@v0` step before the build