### PR TITLE
Switch devbox build to GitHub-hosted runner for OIDC auth

### DIFF
--- a/.github/workflows/devbox-build.yml
+++ b/.github/workflows/devbox-build.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: namespace-profile-default
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The Namespace runner's built-in token doesn't have `devbox/image:wire` permission, and `nscloud-setup` skips OIDC exchange when it detects an existing runner token.

Switching to `ubuntu-latest` so `nscloud-setup` performs a proper GitHub OIDC federation, using the trust relationship grant we configured.