### PR TITLE
Add Namespace runner variant of devbox build workflow

### DIFF
--- a/.github/workflows/devbox-build-nscloud.yml
+++ b/.github/workflows/devbox-build-nscloud.yml
@@ -1,0 +1,16 @@
+name: Build Devbox Image (Namespace Runner)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: nscloud-ubuntu-22.04-amd64-8x16
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Devbox CLI
+        run: curl -fsSL get.namespace.so/devbox/install.sh | bash
+
+      - name: Build Devbox image
+        run: devbox image build . --name=rcrowe-dotfiles -f .devbox/Dockerfile


### PR DESCRIPTION
Adds a second workflow using `nscloud-ubuntu-22.04-amd64-8x16` for testing. Manual dispatch only (no cron) so we can compare against the GitHub-hosted runner version.