### PR TITLE
Force OIDC exchange on Namespace runner for devbox permissions

### DIFF
--- a/.github/workflows/devbox-build-nscloud.yml
+++ b/.github/workflows/devbox-build-nscloud.yml
@@ -3,11 +3,21 @@ name: Build Devbox Image (Namespace Runner)
 on:
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: nscloud-ubuntu-22.04-amd64-8x16
     steps:
       - uses: actions/checkout@v4
+
+      - name: Clear runner token to force OIDC exchange
+        run: rm -f "$NSC_TOKEN_FILE" && unset NSC_TOKEN_FILE
+
+      - name: Configure access to Namespace
+        uses: namespacelabs/nscloud-setup@v0
 
       - name: Install Devbox CLI
         run: curl -fsSL get.namespace.so/devbox/install.sh | bash

--- a/.github/workflows/devbox-build-nscloud.yml
+++ b/.github/workflows/devbox-build-nscloud.yml
@@ -13,11 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Clear runner token to force OIDC exchange
-        run: rm -f "$NSC_TOKEN_FILE" && unset NSC_TOKEN_FILE
-
       - name: Configure access to Namespace
         uses: namespacelabs/nscloud-setup@v0
+        env:
+          NSC_TOKEN_FILE: ""
 
       - name: Install Devbox CLI
         run: curl -fsSL get.namespace.so/devbox/install.sh | bash

--- a/.github/workflows/devbox-build-nscloud.yml
+++ b/.github/workflows/devbox-build-nscloud.yml
@@ -10,13 +10,13 @@ permissions:
 jobs:
   build:
     runs-on: nscloud-ubuntu-22.04-amd64-8x16
+    env:
+      NSC_TOKEN_FILE: ""
     steps:
       - uses: actions/checkout@v4
 
       - name: Configure access to Namespace
         uses: namespacelabs/nscloud-setup@v0
-        env:
-          NSC_TOKEN_FILE: ""
 
       - name: Install Devbox CLI
         run: curl -fsSL get.namespace.so/devbox/install.sh | bash


### PR DESCRIPTION
The Namespace runner's built-in token doesn't have `devbox/image:wire` permission. This deletes the runner token and forces `nscloud-setup` to do a GitHub OIDC exchange instead, which gets full workspace access.