### PR TITLE
fix: correct triple dash on --optimize flag in devbox build

### DIFF
--- a/.github/workflows/devbox-build.yml
+++ b/.github/workflows/devbox-build.yml
@@ -25,7 +25,7 @@ jobs:
         run: curl -fsSL get.namespace.so/devbox/install.sh | bash
 
       - name: Build Devbox image
-        run: devbox image build ---optimize=false --name=${{ env.DEVBOX_IMAGE_NAME }} -f .devbox/Dockerfile .
+        run: devbox image build --optimize=false --name=${{ env.DEVBOX_IMAGE_NAME }} -f .devbox/Dockerfile .
 
       - name: Optimise for specific sites
         run: devbox image optimize --name=${{ env.DEVBOX_IMAGE_NAME }} --site=${{ env.DEVBOX_IMAGE_SITES }}


### PR DESCRIPTION
Fixes `bad flag syntax: ---optimize=false` by correcting to `--optimize=false`.